### PR TITLE
Fixing dependencies for Java 8 compiler

### DIFF
--- a/effektif-workflow-impl/pom.xml
+++ b/effektif-workflow-impl/pom.xml
@@ -51,6 +51,12 @@
       <artifactId>httpclient</artifactId>
       <version>4.3.6</version>
     </dependency>
+    
+    <dependency>
+  	  <groupId>org.mozilla</groupId>
+      <artifactId>rhino</artifactId>
+      <version>1.7R3</version>
+    </dependency>
 
     <!-- TEST DEPENDENCIES -->
 

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/script/RhinoObject.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/script/RhinoObject.java
@@ -13,7 +13,7 @@
  * limitations under the License. */
 package com.effektif.workflow.impl.script;
 
-import sun.org.mozilla.javascript.internal.Scriptable;
+import org.mozilla.javascript.Scriptable;
 
 import com.effektif.workflow.impl.data.TypedValueImpl;
 
@@ -22,7 +22,7 @@ import com.effektif.workflow.impl.data.TypedValueImpl;
  * @author Tom Baeyens
  */
 @SuppressWarnings("restriction")
-public class RhinoObject extends sun.org.mozilla.javascript.internal.ScriptableObject {
+public class RhinoObject extends org.mozilla.javascript.ScriptableObject {
   
   TypedValueImpl typedValue;
 

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/script/RhinoSandboxedScriptService.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/script/RhinoSandboxedScriptService.java
@@ -18,12 +18,12 @@ package com.effektif.workflow.impl.script;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import sun.org.mozilla.javascript.internal.ClassShutter;
-import sun.org.mozilla.javascript.internal.Context;
-import sun.org.mozilla.javascript.internal.ContextFactory;
-import sun.org.mozilla.javascript.internal.NativeJavaObject;
-import sun.org.mozilla.javascript.internal.Scriptable;
-import sun.org.mozilla.javascript.internal.WrapFactory;
+import org.mozilla.javascript.ClassShutter;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.NativeJavaObject;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.WrapFactory;
 
 import com.effektif.workflow.impl.configuration.Brewable;
 import com.effektif.workflow.impl.configuration.Brewery;

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/script/RhinoScriptService.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/script/RhinoScriptService.java
@@ -21,10 +21,10 @@ import java.io.StringWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import sun.org.mozilla.javascript.internal.Context;
-import sun.org.mozilla.javascript.internal.ContextAction;
-import sun.org.mozilla.javascript.internal.ContextFactory;
-import sun.org.mozilla.javascript.internal.Scriptable;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextAction;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.Scriptable;
 
 import com.effektif.workflow.api.workflow.Script;
 import com.effektif.workflow.impl.WorkflowParser;
@@ -79,7 +79,7 @@ public class RhinoScriptService extends AbstractScriptService implements ScriptS
         
         ScriptResult scriptResult = new ScriptResult();
         try {
-          sun.org.mozilla.javascript.internal.Script rhinoCompiledScript = (sun.org.mozilla.javascript.internal.Script) script.compiledScript;
+          org.mozilla.javascript.Script rhinoCompiledScript = (org.mozilla.javascript.Script) script.compiledScript;
           Object result = rhinoCompiledScript.exec(context, rhinoVariableScope);
           
           if (script.expectedResultType!=null && result!=null) {

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/script/RhinoVariableScope.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/script/RhinoVariableScope.java
@@ -27,13 +27,13 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import sun.org.mozilla.javascript.internal.Callable;
-import sun.org.mozilla.javascript.internal.Context;
-import sun.org.mozilla.javascript.internal.IdFunctionObject;
-import sun.org.mozilla.javascript.internal.NativeArray;
-import sun.org.mozilla.javascript.internal.NativeObject;
-import sun.org.mozilla.javascript.internal.Scriptable;
-import sun.org.mozilla.javascript.internal.ScriptableObject;
+import org.mozilla.javascript.Callable;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.IdFunctionObject;
+import org.mozilla.javascript.NativeArray;
+import org.mozilla.javascript.NativeObject;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 
 import com.effektif.workflow.impl.data.DataType;
 import com.effektif.workflow.impl.data.TypedValueImpl;

--- a/effektif-workflow-impl/src/test/java/com/effektif/workflow/test/implementation/RhinoTest.java
+++ b/effektif-workflow-impl/src/test/java/com/effektif/workflow/test/implementation/RhinoTest.java
@@ -18,10 +18,10 @@ import java.io.StringWriter;
 
 import org.junit.Test;
 
-import sun.org.mozilla.javascript.internal.Context;
-import sun.org.mozilla.javascript.internal.ContextAction;
-import sun.org.mozilla.javascript.internal.ContextFactory;
-import sun.org.mozilla.javascript.internal.Scriptable;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextAction;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.Scriptable;
 
 import com.effektif.workflow.impl.script.RhinoVariableScope;
 
@@ -64,7 +64,7 @@ public class RhinoTest {
         
         Object result = null;
         try {
-          sun.org.mozilla.javascript.internal.Script rhinoCompiledScript = (sun.org.mozilla.javascript.internal.Script) script;
+          org.mozilla.javascript.Script rhinoCompiledScript = (org.mozilla.javascript.Script) script;
           result = rhinoCompiledScript.exec(context, rhinoVariableScope);
           
         } catch (Exception e) {
@@ -76,7 +76,7 @@ public class RhinoTest {
   }
   
   @SuppressWarnings("restriction")
-  public static class MagicScriptableObject extends sun.org.mozilla.javascript.internal.ScriptableObject {
+  public static class MagicScriptableObject extends org.mozilla.javascript.ScriptableObject {
     String name;
     public MagicScriptableObject(String name) {
       this.name = name;

--- a/pom.xml
+++ b/pom.xml
@@ -92,10 +92,6 @@
           <encoding>UTF-8</encoding>
           <source>1.7</source>
           <target>1.7</target>
-          <compilerArguments>
-            <!-- This is to get the Rhino internal classes compiled -->
-            <bootclasspath>${java.home}/lib/rt.jar</bootclasspath>
-          </compilerArguments>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
That changes the Rhino dependency to use external one instead internal (rt.jar). It will allows the build using JDK 8