### PR TITLE
Workflow migrator

### DIFF
--- a/effektif-mongo/src/main/java/com/effektif/mongo/LoggingCursor.java
+++ b/effektif-mongo/src/main/java/com/effektif/mongo/LoggingCursor.java
@@ -160,7 +160,9 @@ public class LoggingCursor extends DBCursor {
 
   @Override
   public DBCursor addOption(int option) {
-    return cursor.addOption(option);
+    if(cursor != null) return cursor.addOption(option);
+    else return this;
+    //JB:was: return cursor.addOption(option);
   }
 
   @Override

--- a/effektif-mongo/src/main/java/com/effektif/mongo/LoggingCursor.java
+++ b/effektif-mongo/src/main/java/com/effektif/mongo/LoggingCursor.java
@@ -160,9 +160,7 @@ public class LoggingCursor extends DBCursor {
 
   @Override
   public DBCursor addOption(int option) {
-    if(cursor != null) return cursor.addOption(option);
-    else return this;
-    //JB:was: return cursor.addOption(option);
+    return cursor.addOption(option);
   }
 
   @Override

--- a/effektif-mongo/src/main/java/com/effektif/mongo/MongoWorkflowInstanceStore.java
+++ b/effektif-mongo/src/main/java/com/effektif/mongo/MongoWorkflowInstanceStore.java
@@ -381,6 +381,11 @@ public class MongoWorkflowInstanceStore implements WorkflowInstanceStore, Brewab
   }
 
   @Override
+  public WorkflowInstanceImpl lockWorkflowInstance(WorkflowInstanceId workflowInstanceId) {
+    return lockWorkflowInstance(workflowInstanceId, workflowEngine.getId());
+  }
+
+  @Override
   public void unlockWorkflowInstance(WorkflowInstanceId workflowInstanceId) {
     workflowInstancesCollection.update("unlock-workflow-instance", 
       new Query()

--- a/effektif-mongo/src/main/java/com/effektif/mongo/MongoWorkflowInstanceStore.java
+++ b/effektif-mongo/src/main/java/com/effektif/mongo/MongoWorkflowInstanceStore.java
@@ -389,8 +389,8 @@ public class MongoWorkflowInstanceStore implements WorkflowInstanceStore, Brewab
 
     long count = workflowInstancesCollection.count("count-workflowInstance-migrate", countQuery);
 
-    if (count > 0) return count; // fail
-    else return null; // success
+    if (count > 0) return null; // fail
+    else return new Long(0); // success
   }
 
   @Override
@@ -398,19 +398,19 @@ public class MongoWorkflowInstanceStore implements WorkflowInstanceStore, Brewab
     BasicDBObject query;
     BasicDBObject update;
 
-    query = new BasicDBObject(WorkflowInstanceFields.WORKFLOW_ID, fromWorkfowId)
+    query = new BasicDBObject(WorkflowInstanceFields.WORKFLOW_ID, new ObjectId(fromWorkfowId))
             .append(getLockOwnerField(), uniqueOwner);
 
-    BasicDBObject unset = new BasicDBObject(getLockOwnerField(), 1);
+    BasicDBObject unset = new BasicDBObject(WorkflowInstanceFields.LOCK, 1);
 
     update = new BasicDBObject("$unset", unset);
 
     if (toWorkflowId != null) {
-      BasicDBObject set = new BasicDBObject(WorkflowInstanceFields.WORKFLOW_ID, toWorkflowId);
+      BasicDBObject set = new BasicDBObject(WorkflowInstanceFields.WORKFLOW_ID, new ObjectId(toWorkflowId));
       update.append("$set", set);
     }
 
-    workflowInstancesCollection.findAndModify("unlock-workflowInstance-migrate", query, update);
+    workflowInstancesCollection.update("unlock-workflowInstance-migrate", query, update, false, true);
   }
 
   private static String getLockOwnerField() {

--- a/effektif-mongo/src/test/java/com/effektif/mongo/test/FindByActivityIdTest.java
+++ b/effektif-mongo/src/test/java/com/effektif/mongo/test/FindByActivityIdTest.java
@@ -7,7 +7,9 @@ import com.effektif.workflow.api.activities.*;
 import com.effektif.workflow.api.model.Deployment;
 import com.effektif.workflow.api.model.TriggerInstance;
 import com.effektif.workflow.api.query.WorkflowInstanceQuery;
+import com.effektif.workflow.api.query.WorkflowQuery;
 import com.effektif.workflow.api.workflow.ExecutableWorkflow;
+import com.effektif.workflow.api.workflow.WorkflowInstanceMigrator;
 import com.effektif.workflow.api.workflowinstance.WorkflowInstance;
 
 import java.util.List;
@@ -26,13 +28,11 @@ public class FindByActivityIdTest {
                 .databaseName("effektif");
 
         cachedConfiguration = mongoConfiguration;
+//        cachedConfiguration = new MemoryConfiguration();
 
         WorkflowEngine workflowEngine = cachedConfiguration.getWorkflowEngine();
 
         // Create a workflow
-        ExecutableWorkflow f = new ExecutableWorkflow();
-
-
         ExecutableWorkflow workflow1 = new ExecutableWorkflow()
                 .sourceWorkflowId("Server test workflow")
                 .activity("One", new StartEvent()
@@ -50,32 +50,59 @@ public class FindByActivityIdTest {
         TriggerInstance start = new TriggerInstance()
                 .workflowId(deployment.getWorkflowId());
 
-        WorkflowInstance workflowInstance = workflowEngine.start(start);
+        workflowEngine.start(start);
 
         // Now find all workflowInstances in a particular ActivityId, they should be in "Three"
-        WorkflowInstanceQuery workflowInstanceQuery = new WorkflowInstanceQuery()
+        WorkflowInstanceQuery activityIdQuery = new WorkflowInstanceQuery()
                 .activityId("Three");
 
-        WorkflowInstanceQuery workflowInstanceQuery2 = new WorkflowInstanceQuery();
-//                .workflowInstanceId(workflowInstance.getId());
+        WorkflowInstanceQuery workflowIdQuery = new WorkflowInstanceQuery().workflowId(deployment.getWorkflowId().getInternal());
 
-        List<WorkflowInstance> workflowInstances = workflowEngine.findWorkflowInstances(workflowInstanceQuery);
+        List<WorkflowInstance> workflowInstancesInThree = workflowEngine.findWorkflowInstances(activityIdQuery);
+        List<WorkflowInstance> workflowInstancesInWorkflow = workflowEngine.findWorkflowInstances(workflowIdQuery);
 
-        List<WorkflowInstance> workflowInstances2 = workflowEngine.findWorkflowInstances(workflowInstanceQuery2);
+        System.out.println("Nr of workflowInstances in activity Three: " + workflowInstancesInThree.size() + " (should be 1)");
+        System.out.println("Nr of workflowInstances in the Workflow: " + workflowInstancesInWorkflow.size() + " (should be 1)");
 
-        System.out.println("Nr of workflowInstances found: " + workflowInstances.size() + " (should be 1)");
-        System.out.println("Nr of workflowInstances found: " + workflowInstances2.size() + " (should be 1)");
+        assert workflowInstancesInThree.size() == 1;
+        assert workflowInstancesInWorkflow.size() == 1;
 
-        TriggerInstance start2 = new TriggerInstance()
-                .workflowId(deployment.getWorkflowId());
+        workflowEngine.start(start);
 
-        workflowInstance = workflowEngine.start(start);
+        workflowInstancesInThree = workflowEngine.findWorkflowInstances(activityIdQuery);
+        workflowInstancesInWorkflow = workflowEngine.findWorkflowInstances(workflowIdQuery);
 
-        List<WorkflowInstance> workflowInstances3 = workflowEngine.findWorkflowInstances(workflowInstanceQuery2);
+        System.out.println("Now nr of workflowInstances in activity Three: " + workflowInstancesInThree.size() + " (should be 2)");
+        System.out.println("Now nr of workflowInstances in the Workflow: " + workflowInstancesInWorkflow.size() + " (should be 2)");
 
-        System.out.println("Nr of workflowInstances found: " + workflowInstances.size() + " (should be 1)");
-        System.out.println("Nr of workflowInstances found: " + workflowInstances2.size() + " (should be 1)");
-        System.out.println("Nr of workflowInstances found: " + workflowInstances3.size() + " (should be 2)");
+        assert workflowInstancesInThree.size() == 2;
+        assert workflowInstancesInWorkflow.size() == 2;
+
+        // Test migration, just redeploy the workflow and migrate workflowInstances.
+        WorkflowInstanceMigrator migrator = new WorkflowInstanceMigrator().originalWorkflowId(deployment.getWorkflowId().getInternal());
+
+        workflow1.setId(null);
+        Deployment deployment2 = workflowEngine.deployWorkflow(workflow1, migrator);
+
+        // check migration
+        WorkflowInstanceQuery newWorkflowIdQuery = new WorkflowInstanceQuery().workflowId(deployment2.getWorkflowId().getInternal());
+
+        workflowInstancesInThree = workflowEngine.findWorkflowInstances(activityIdQuery);
+        workflowInstancesInWorkflow = workflowEngine.findWorkflowInstances(newWorkflowIdQuery);
+        List<WorkflowInstance> workflowInstancesInOldWorkflow = workflowEngine.findWorkflowInstances(workflowIdQuery);
+
+        System.out.println("After migration, nr of workflowInstances in activity Three: " + workflowInstancesInThree.size() + " (should be 2)");
+        System.out.println("After migration, nr of workflowInstances in the new Workflow: " + workflowInstancesInWorkflow.size() + " (should be 2)");
+        System.out.println("After migration, nr of workflowInstances in the new Workflow: " + workflowInstancesInOldWorkflow.size() + " (should be 0)");
+
+        assert workflowInstancesInThree.size() == 2;
+        assert workflowInstancesInWorkflow.size() == 2;
+        assert workflowInstancesInOldWorkflow.size() == 0;
+
+        // clean up
+        workflowEngine.deleteWorkflowInstances(workflowIdQuery);
+        workflowEngine.deleteWorkflows(new WorkflowQuery().workflowId(deployment.getWorkflowId()));
+        workflowEngine.deleteWorkflows(new WorkflowQuery().workflowId(deployment2.getWorkflowId()));
 
     }
 

--- a/effektif-workflow-api/src/main/java/com/effektif/workflow/api/WorkflowEngine.java
+++ b/effektif-workflow-api/src/main/java/com/effektif/workflow/api/WorkflowEngine.java
@@ -25,6 +25,7 @@ import com.effektif.workflow.api.model.WorkflowInstanceId;
 import com.effektif.workflow.api.query.WorkflowInstanceQuery;
 import com.effektif.workflow.api.query.WorkflowQuery;
 import com.effektif.workflow.api.workflow.ExecutableWorkflow;
+import com.effektif.workflow.api.workflow.WorkflowInstanceMigrator;
 import com.effektif.workflow.api.workflowinstance.WorkflowInstance;
 
 
@@ -40,7 +41,9 @@ public interface WorkflowEngine {
 
   /** Validates and deploys if there are no errors. */
   Deployment deployWorkflow(ExecutableWorkflow workflow);
-  
+
+  Deployment deployWorkflow(ExecutableWorkflow workflow, WorkflowInstanceMigrator migrator);
+
   List<ExecutableWorkflow> findWorkflows(WorkflowQuery workflowQuery);
 
   void deleteWorkflows(WorkflowQuery workflowQuery);

--- a/effektif-workflow-api/src/main/java/com/effektif/workflow/api/query/WorkflowInstanceQuery.java
+++ b/effektif-workflow-api/src/main/java/com/effektif/workflow/api/query/WorkflowInstanceQuery.java
@@ -30,6 +30,7 @@ public class WorkflowInstanceQuery {
 
   protected WorkflowInstanceId workflowInstanceId;
   protected String activityId;
+  protected String workflowId;
   protected Integer skip;
   protected Integer limit;
   protected List<OrderBy> orderBy;
@@ -61,6 +62,18 @@ public class WorkflowInstanceQuery {
     this.activityId = activityId;
   }
 
+  public WorkflowInstanceQuery workflowId(String workflowId) {
+    setWorkflowId(workflowId);
+    return this;
+  }
+
+  public String getWorkflowId() {
+    return workflowId;
+  }
+
+  public void setWorkflowId(String workflowId) {
+    this.workflowId = workflowId;
+  }
 
   public Integer getSkip() {
     return this.skip;

--- a/effektif-workflow-api/src/main/java/com/effektif/workflow/api/workflow/WorkflowInstanceMigrator.java
+++ b/effektif-workflow-api/src/main/java/com/effektif/workflow/api/workflow/WorkflowInstanceMigrator.java
@@ -1,8 +1,7 @@
 package com.effektif.workflow.api.workflow;
 
 /**
- * CumulusPro
- * Created by Jeroen on 13/08/15.
+ * Created by Jeroen on 20/08/15.
  */
 public class WorkflowInstanceMigrator {
 
@@ -11,8 +10,8 @@ public class WorkflowInstanceMigrator {
     }
 
     public WorkflowInstanceMigrator sourceWorkflowId(String sourceWorkflowId) {
-        this.sourceWorkflowId = sourceWorkflowId;
+        this.fromWorkflowId = sourceWorkflowId;
         return this;
     }
-    public String sourceWorkflowId;
+    public String fromWorkflowId;
 }

--- a/effektif-workflow-api/src/main/java/com/effektif/workflow/api/workflow/WorkflowInstanceMigrator.java
+++ b/effektif-workflow-api/src/main/java/com/effektif/workflow/api/workflow/WorkflowInstanceMigrator.java
@@ -5,13 +5,10 @@ package com.effektif.workflow.api.workflow;
  */
 public class WorkflowInstanceMigrator {
 
-    public WorkflowInstanceMigrator WorkflowInstanceMigrator() {
+    public WorkflowInstanceMigrator originalWorkflowId(String sourceWorkflowId) {
+        this.originalWorkflowId = sourceWorkflowId;
         return this;
     }
 
-    public WorkflowInstanceMigrator sourceWorkflowId(String sourceWorkflowId) {
-        this.fromWorkflowId = sourceWorkflowId;
-        return this;
-    }
-    public String fromWorkflowId;
+    public String originalWorkflowId;
 }

--- a/effektif-workflow-api/src/main/java/com/effektif/workflow/api/workflow/WorkflowInstanceMigrator.java
+++ b/effektif-workflow-api/src/main/java/com/effektif/workflow/api/workflow/WorkflowInstanceMigrator.java
@@ -1,0 +1,18 @@
+package com.effektif.workflow.api.workflow;
+
+/**
+ * CumulusPro
+ * Created by Jeroen on 13/08/15.
+ */
+public class WorkflowInstanceMigrator {
+
+    public WorkflowInstanceMigrator WorkflowInstanceMigrator() {
+        return this;
+    }
+
+    public WorkflowInstanceMigrator sourceWorkflowId(String sourceWorkflowId) {
+        this.sourceWorkflowId = sourceWorkflowId;
+        return this;
+    }
+    public String sourceWorkflowId;
+}

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
@@ -119,31 +119,36 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
   @Override
   public Deployment deployWorkflow(ExecutableWorkflow workflow, WorkflowInstanceMigrator migrator) {
 
-    Deployment deployment = deployWorkflow(workflow);
+    Deployment deployment = null;
 
-    if (migrator!=null && migrator.fromWorkflowId != null && !deployment.hasErrors()) {
+    if (migrator!=null && migrator.fromWorkflowId != null) {
       // create a unique lockOwner for the migration
       UUID uuid = UUID.randomUUID();
 
       String uniqueLockOwner = getId() + "-" + uuid.toString();
 
-      log.debug("Migrating workflow " + migrator.fromWorkflowId + " to workflow with id: " + workflow.getId().getInternal());
+      log.debug("Migration from workflow " + migrator.fromWorkflowId + " started, locking workflowInstances.");
 
       Long lockResult = lockAllWorkflowInstancesWithRetry(migrator.fromWorkflowId, uniqueLockOwner);
 
-      if (lockResult == null) {
+      if (lockResult != null) {
         // Update to new workflow and unlock all
+        deployment = deployWorkflow(workflow);
+
+        log.debug("Locking done, now migrating from workflow " + migrator.fromWorkflowId + " to workflow " + deployment.getWorkflowId() + ", and unlocking.");
+
         workflowInstanceStore.migrateAndUnlockAllLockedWorkflowInstances(migrator.fromWorkflowId, deployment.getWorkflowId().getInternal(), uniqueLockOwner);
       } else {
+        deployment = new Deployment();
         // Just unlock all
         log.debug("Failed to get a lock on all workflowInstances of workflow " + migrator.fromWorkflowId + ". Unlocking and aborting migration.");
 
-        workflowInstanceStore.migrateAndUnlockAllLockedWorkflowInstances(migrator.fromWorkflowId, deployment.getWorkflowId().getInternal(), uniqueLockOwner);
+        workflowInstanceStore.migrateAndUnlockAllLockedWorkflowInstances(migrator.fromWorkflowId, null, uniqueLockOwner);
 
         deployment.addIssue(ParseIssue.IssueType.error, null, null, null, "Migration of workflowInstances of the old workflow failed, because migration failed to get a lock on all workflowInstances of workflow " + migrator.fromWorkflowId, null);
       }
 
-      log.debug("Migration of workflowId " + migrator.fromWorkflowId + "to workflowId " + deployment.getWorkflowId() + " ended.");
+      log.debug("Migration of workflowId " + migrator.fromWorkflowId + " to workflowId " + deployment.getWorkflowId() + " finished.");
     }
 
     return deployment;

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
@@ -138,6 +138,8 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
         log.debug("Locking done, now migrating from workflow " + migrator.fromWorkflowId + " to workflow " + deployment.getWorkflowId() + ", and unlocking.");
 
         workflowInstanceStore.migrateAndUnlockAllLockedWorkflowInstances(migrator.fromWorkflowId, deployment.getWorkflowId().getInternal(), uniqueLockOwner);
+
+        log.debug("Migration of workflowId " + migrator.fromWorkflowId + " to workflowId " + deployment.getWorkflowId() + " finished.");
       } else {
         deployment = new Deployment();
         // Just unlock all
@@ -147,8 +149,6 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
 
         deployment.addIssue(ParseIssue.IssueType.error, null, null, null, "Migration of workflowInstances of the old workflow failed, because migration failed to get a lock on all workflowInstances of workflow " + migrator.fromWorkflowId, null);
       }
-
-      log.debug("Migration of workflowId " + migrator.fromWorkflowId + " to workflowId " + deployment.getWorkflowId() + " finished.");
     }
 
     return deployment;
@@ -292,7 +292,7 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
 
       @Override
       protected void failedWaitingForRetry() {
-        log.debug("Locking workflowInstances for workflow migration failed.... retrying in " + wait + " millis.");
+        log.debug("Locking all workflowInstances for workflow " + workflowId + " failed.... retrying in " + wait + " millis.");
       }
     };
 

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
@@ -126,6 +126,8 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
 
       String uniqueLockOwner = getId() + "-" + uuid.toString();
 
+      log.debug("Migrating workflow " + migrator.sourceWorkflowId + " to workflow with id: " + workflow.getId().getInternal());
+
       WorkflowImpl workflowImpl = getWorkflowImpl(deployment.getWorkflowId());
 
       List<String> workflowInstances = workflowInstanceStore.findWorkflowInstanceIds(new WorkflowInstanceQuery().workflowId(migrator.sourceWorkflowId));
@@ -137,6 +139,8 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
         wfImpl.migrateToWorkflow(workflowImpl);
         workflowInstanceStore.flushAndUnlock(wfImpl);
       }
+
+      log.debug("Migration ended, nr of objects migrated: " + workflowInstances.size());
     }
 
     return deployment;

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
@@ -137,59 +137,6 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
         wfImpl.migrateToWorkflow(workflowImpl);
         workflowInstanceStore.flushAndUnlock(wfImpl);
       }
-
-//      List<WorkflowInstanceImpl> workflowInstances = workflowInstanceStore.findWorkflowInstances(new WorkflowInstanceQuery().workflowId(migrator.sourceWorkflowId));
-//
-//      for (WorkflowInstanceImpl workflowInstance : workflowInstances) {
-//        WorkflowInstanceImpl wfImpl = lockWorkflowInstanceWithRetry(workflowInstance.getId(), uniqueLockOwner);
-//
-//        wfImpl.trackUpdates(false);
-//        wfImpl.migrateToWorkflow(workflowImpl);
-//        workflowInstanceStore.flushAndUnlock(wfImpl);
-//      }
-
-
-//
-//
-//
-//
-//      // lock all workflow instances that don’t have a lock at the moment, bulk operation.
-//      int lockedWorkflowInstances = workflowInstanceStore.lockAllWorkflowInstances(migrator.sourceWorkflowId, uniqueLockOwner);
-//
-//      // only lock instances that have no lock
-//      // if there are workflow instances that still need to be migrated
-//      // only lock workflow instances in the previous version!
-//      WorkflowInstanceQuery unlockedInsQry = new WorkflowInstanceQuery().workflowId(migrator.sourceWorkflowId);
-//      List<String> workflowInstances = workflowInstanceStore.findWorkflowInstancesNotLockedByOwner(unlockedInsQry, uniqueLockOwner);
-//
-//      for (String workflowInstanceId : workflowInstances) {
-//        try {
-//          WorkflowInstanceImpl wfi = lockWorkflowInstanceWithRetry(new WorkflowInstanceId(workflowInstanceId), uniqueLockOwner);
-//
-//          if (wfi != null) lockedWorkflowInstances++;
-//        } catch (RuntimeException rE) {
-//          log.warn("Could not migrate workflowInstance with id: " + workflowInstanceId, rE);
-//        }
-//      }
-//
-//      log.debug("Locked " + lockedWorkflowInstances + " workflowInstances for migrating from workflow " + migrator.sourceWorkflowId +
-//              " to workflow " + deployment.getWorkflowId());
-//
-//      List<WorkflowInstanceImpl> migratibleWorkflowInstances =  workflowInstanceStore.findLockedWorkflowInstances(new WorkflowInstanceQuery().workflowId(migrator.sourceWorkflowId), uniqueLockOwner);
-//
-//      if (migratibleWorkflowInstances.size() != lockedWorkflowInstances) {
-//        log.warn("The number of workflowInstances locked is different from the number of workflowInstances that will be migrated to the new workflow.");
-//      }
-//
-//      WorkflowImpl workflowImpl = getWorkflowImpl(deployment.getWorkflowId());
-//
-//      for (WorkflowInstanceImpl worklfowInstance : migratibleWorkflowInstances) {
-//
-//        worklfowInstance.trackUpdates(false);
-//        worklfowInstance.migrateToWorkflow(workflowImpl);
-//        workflowInstanceStore.flushAndUnlock(worklfowInstance);
-//
-//      }
     }
 
     return deployment;

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
@@ -121,33 +121,33 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
 
     Deployment deployment = null;
 
-    if (migrator!=null && migrator.fromWorkflowId != null) {
+    if (migrator!=null && migrator.originalWorkflowId != null) {
       // create a unique lockOwner for the migration
       UUID uuid = UUID.randomUUID();
 
       String uniqueLockOwner = getId() + "-" + uuid.toString();
 
-      log.debug("Migration from workflow " + migrator.fromWorkflowId + " started, locking workflowInstances.");
+      log.debug("Migration from workflow " + migrator.originalWorkflowId + " started, locking workflowInstances.");
 
-      Long lockResult = lockAllWorkflowInstancesWithRetry(migrator.fromWorkflowId, uniqueLockOwner);
+      Long lockResult = lockAllWorkflowInstancesWithRetry(migrator.originalWorkflowId, uniqueLockOwner);
 
       if (lockResult != null) {
         // Update to new workflow and unlock all
         deployment = deployWorkflow(workflow);
 
-        log.debug("Locking done, now migrating from workflow " + migrator.fromWorkflowId + " to workflow " + deployment.getWorkflowId() + ", and unlocking.");
+        log.debug("Locking done, now migrating from workflow " + migrator.originalWorkflowId + " to workflow " + deployment.getWorkflowId() + ", and unlocking.");
 
-        workflowInstanceStore.migrateAndUnlockAllLockedWorkflowInstances(migrator.fromWorkflowId, deployment.getWorkflowId().getInternal(), uniqueLockOwner);
+        workflowInstanceStore.migrateAndUnlockAllLockedWorkflowInstances(migrator.originalWorkflowId, deployment.getWorkflowId().getInternal(), uniqueLockOwner);
 
-        log.debug("Migration of workflowId " + migrator.fromWorkflowId + " to workflowId " + deployment.getWorkflowId() + " finished.");
+        log.debug("Migration of workflowId " + migrator.originalWorkflowId + " to workflowId " + deployment.getWorkflowId() + " finished.");
       } else {
         deployment = new Deployment();
         // Just unlock all
-        log.debug("Failed to get a lock on all workflowInstances of workflow " + migrator.fromWorkflowId + ". Unlocking and aborting migration.");
+        log.debug("Failed to get a lock on all workflowInstances of workflow " + migrator.originalWorkflowId + ". Unlocking and aborting migration.");
 
-        workflowInstanceStore.migrateAndUnlockAllLockedWorkflowInstances(migrator.fromWorkflowId, null, uniqueLockOwner);
+        workflowInstanceStore.migrateAndUnlockAllLockedWorkflowInstances(migrator.originalWorkflowId, null, uniqueLockOwner);
 
-        deployment.addIssue(ParseIssue.IssueType.error, null, null, null, "Migration of workflowInstances of the old workflow failed, because migration failed to get a lock on all workflowInstances of workflow " + migrator.fromWorkflowId, null);
+        deployment.addIssue(ParseIssue.IssueType.error, null, null, null, "Migration of workflowInstances of the old workflow failed, because migration failed to get a lock on all workflowInstances of workflow " + migrator.originalWorkflowId, null);
       }
     }
 

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowInstanceStore.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowInstanceStore.java
@@ -23,7 +23,7 @@ import com.effektif.workflow.impl.workflowinstance.WorkflowInstanceImpl;
 
 
 public interface WorkflowInstanceStore {
-  
+
   WorkflowInstanceId generateWorkflowInstanceId();
 
   void insertWorkflowInstance(WorkflowInstanceImpl worklflowInstance);
@@ -31,9 +31,11 @@ public interface WorkflowInstanceStore {
   /** used when rendering a form */
   WorkflowInstanceImpl getWorkflowInstanceImplById(WorkflowInstanceId workflowInstanceId);
 
-  WorkflowInstanceImpl lockWorkflowInstance(WorkflowInstanceId workflowInstanceId, String owner);
-
   WorkflowInstanceImpl lockWorkflowInstance(WorkflowInstanceId workflowInstanceId);
+
+  Long lockAllWorkflowInstances(String workflowId, String uniqueOwner);
+
+  void migrateAndUnlockAllLockedWorkflowInstances(String fromWorkflowId, String toWorkflowId, String uniqueOwner);
 
   WorkflowInstanceImpl lockWorkflowInstanceWithJobsDue();
 
@@ -45,9 +47,8 @@ public interface WorkflowInstanceStore {
 
   List<WorkflowInstanceImpl> findWorkflowInstances(WorkflowInstanceQuery workflowInstanceQuery);
 
-  List<String> findWorkflowInstanceIds(WorkflowInstanceQuery workflowInstanceQuery);
-
   void deleteWorkflowInstances(WorkflowInstanceQuery workflowInstanceQuery);
 
   void deleteAllWorkflowInstances();
+
 }

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowInstanceStore.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowInstanceStore.java
@@ -33,6 +33,8 @@ public interface WorkflowInstanceStore {
 
   WorkflowInstanceImpl lockWorkflowInstance(WorkflowInstanceId workflowInstanceId, String owner);
 
+  WorkflowInstanceImpl lockWorkflowInstance(WorkflowInstanceId workflowInstanceId);
+
   WorkflowInstanceImpl lockWorkflowInstanceWithJobsDue();
 
   void flush(WorkflowInstanceImpl workflowInstance);

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowInstanceStore.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowInstanceStore.java
@@ -33,8 +33,6 @@ public interface WorkflowInstanceStore {
 
   WorkflowInstanceImpl lockWorkflowInstance(WorkflowInstanceId workflowInstanceId, String owner);
 
-  int lockAllWorkflowInstances(String workflowId, String uniqueOwner);
-
   WorkflowInstanceImpl lockWorkflowInstanceWithJobsDue();
 
   void flush(WorkflowInstanceImpl workflowInstance);
@@ -45,7 +43,7 @@ public interface WorkflowInstanceStore {
 
   List<WorkflowInstanceImpl> findWorkflowInstances(WorkflowInstanceQuery workflowInstanceQuery);
 
-  List<String> findWorkflowInstancesNotLockedByOwner(WorkflowInstanceQuery unlockedInsQry, String uniqueLockOwner);
+  List<String> findWorkflowInstanceIds(WorkflowInstanceQuery workflowInstanceQuery);
 
   void deleteWorkflowInstances(WorkflowInstanceQuery workflowInstanceQuery);
 

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowInstanceStore.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowInstanceStore.java
@@ -31,7 +31,9 @@ public interface WorkflowInstanceStore {
   /** used when rendering a form */
   WorkflowInstanceImpl getWorkflowInstanceImplById(WorkflowInstanceId workflowInstanceId);
 
-  WorkflowInstanceImpl lockWorkflowInstance(WorkflowInstanceId workflowInstanceId);
+  WorkflowInstanceImpl lockWorkflowInstance(WorkflowInstanceId workflowInstanceId, String owner);
+
+  int lockAllWorkflowInstances(String workflowId, String uniqueOwner);
 
   WorkflowInstanceImpl lockWorkflowInstanceWithJobsDue();
 
@@ -43,8 +45,9 @@ public interface WorkflowInstanceStore {
 
   List<WorkflowInstanceImpl> findWorkflowInstances(WorkflowInstanceQuery workflowInstanceQuery);
 
+  List<String> findWorkflowInstancesNotLockedByOwner(WorkflowInstanceQuery unlockedInsQry, String uniqueLockOwner);
+
   void deleteWorkflowInstances(WorkflowInstanceQuery workflowInstanceQuery);
 
   void deleteAllWorkflowInstances();
-
 }

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/memory/MemoryWorkflowInstanceStore.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/memory/MemoryWorkflowInstanceStore.java
@@ -15,17 +15,7 @@
  */
 package com.effektif.workflow.impl.memory;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.slf4j.Logger;
-
+import com.effektif.workflow.api.model.WorkflowId;
 import com.effektif.workflow.api.model.WorkflowInstanceId;
 import com.effektif.workflow.api.query.WorkflowInstanceQuery;
 import com.effektif.workflow.impl.WorkflowEngineImpl;
@@ -35,9 +25,13 @@ import com.effektif.workflow.impl.configuration.Brewery;
 import com.effektif.workflow.impl.job.Job;
 import com.effektif.workflow.impl.util.Lists;
 import com.effektif.workflow.impl.util.Time;
+import com.effektif.workflow.impl.workflow.WorkflowImpl;
 import com.effektif.workflow.impl.workflowinstance.LockImpl;
 import com.effektif.workflow.impl.workflowinstance.WorkflowInstanceImpl;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+import org.slf4j.Logger;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 
 /**
@@ -48,6 +42,7 @@ public class MemoryWorkflowInstanceStore implements WorkflowInstanceStore, Brewa
   private static final Logger log = WorkflowEngineImpl.log;
 
   protected String workflowEngineId;
+  protected WorkflowEngineImpl engine;
   protected Map<WorkflowInstanceId, WorkflowInstanceImpl> workflowInstances;
   protected Set<WorkflowInstanceId> lockedWorkflowInstanceIds;
   
@@ -58,6 +53,7 @@ public class MemoryWorkflowInstanceStore implements WorkflowInstanceStore, Brewa
   public void brew(Brewery brewery) {
     initializeWorkflowInstances();
     this.workflowEngineId = brewery.get(WorkflowEngineImpl.class).id;
+    this.engine = brewery.get(WorkflowEngineImpl.class);
   }
 
   protected void initializeWorkflowInstances() {
@@ -101,7 +97,7 @@ public class MemoryWorkflowInstanceStore implements WorkflowInstanceStore, Brewa
       if (workflowInstance!=null && workflowInstance.isIncluded(query)) {
         return Lists.of(workflowInstance);
       } else {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
       }
     }
     List<WorkflowInstanceImpl> workflowInstances = new ArrayList<>();
@@ -141,19 +137,39 @@ public class MemoryWorkflowInstanceStore implements WorkflowInstanceStore, Brewa
       throw new RuntimeException("Process instance doesn't exist");
     }
     WorkflowInstanceImpl workflowInstance = workflowInstances.get(0);
-    workflowInstanceId = workflowInstance.id;
     lockWorkflowInstance(workflowInstance);
     return workflowInstance;
   }
 
   @Override
   public Long lockAllWorkflowInstances(String workflowId, String uniqueOwner) {
-    throw new NotImplementedException();
+    long lockedInstances = 0;
+    WorkflowInstanceQuery query = new WorkflowInstanceQuery().workflowId(workflowId);
+    List<WorkflowInstanceImpl> workflowInstances = findWorkflowInstances(query);
+    for(WorkflowInstanceImpl workflowInstance : workflowInstances) {
+      try {
+        lockWorkflowInstance(workflowInstance);
+      } catch (RuntimeException ex) {
+        lockedInstances++;
+      }
+    }
+
+    if (lockedInstances > 0) return null; // fail
+    else return (long) 0; // success
   }
 
   @Override
   public void migrateAndUnlockAllLockedWorkflowInstances(String fromWorkflowId, String toWorkflowId, String uniqueOwner) {
-    throw new NotImplementedException();
+    WorkflowInstanceQuery query = new WorkflowInstanceQuery().workflowId(fromWorkflowId);
+
+    WorkflowImpl newWorkflow = engine.getWorkflowImpl(new WorkflowId(toWorkflowId));
+
+    List<WorkflowInstanceImpl> workflowInstances = findWorkflowInstances(query);
+    for(WorkflowInstanceImpl workflowInstance : workflowInstances) {
+      workflowInstance.workflow = newWorkflow;
+
+      flushAndUnlock(workflowInstance);
+    }
   }
 
   public synchronized void lockWorkflowInstance(WorkflowInstanceImpl workflowInstance) {

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/memory/MemoryWorkflowInstanceStore.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/memory/MemoryWorkflowInstanceStore.java
@@ -132,12 +132,7 @@ public class MemoryWorkflowInstanceStore implements WorkflowInstanceStore, Brewa
   }
 
   @Override
-  public List<String> findWorkflowInstanceIds(WorkflowInstanceQuery workflowInstanceQuery) {
-    throw new NotImplementedException();
-  }
-
-  @Override
-  public WorkflowInstanceImpl lockWorkflowInstance(WorkflowInstanceId workflowInstanceId, String owner) {
+  public WorkflowInstanceImpl lockWorkflowInstance(WorkflowInstanceId workflowInstanceId) {
     WorkflowInstanceQuery query = new WorkflowInstanceQuery()
       .workflowInstanceId(workflowInstanceId);
     query.setLimit(1);
@@ -152,8 +147,13 @@ public class MemoryWorkflowInstanceStore implements WorkflowInstanceStore, Brewa
   }
 
   @Override
-  public WorkflowInstanceImpl lockWorkflowInstance(WorkflowInstanceId workflowInstanceId) {
-    return lockWorkflowInstance(workflowInstanceId, workflowEngineId);
+  public Long lockAllWorkflowInstances(String workflowId, String uniqueOwner) {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public void migrateAndUnlockAllLockedWorkflowInstances(String fromWorkflowId, String toWorkflowId, String uniqueOwner) {
+    throw new NotImplementedException();
   }
 
   public synchronized void lockWorkflowInstance(WorkflowInstanceImpl workflowInstance) {

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/memory/MemoryWorkflowInstanceStore.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/memory/MemoryWorkflowInstanceStore.java
@@ -37,6 +37,7 @@ import com.effektif.workflow.impl.util.Lists;
 import com.effektif.workflow.impl.util.Time;
 import com.effektif.workflow.impl.workflowinstance.LockImpl;
 import com.effektif.workflow.impl.workflowinstance.WorkflowInstanceImpl;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 
 /**
@@ -131,7 +132,12 @@ public class MemoryWorkflowInstanceStore implements WorkflowInstanceStore, Brewa
   }
 
   @Override
-  public WorkflowInstanceImpl lockWorkflowInstance(WorkflowInstanceId workflowInstanceId) {
+  public List<String> findWorkflowInstanceIds(WorkflowInstanceQuery workflowInstanceQuery) {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public WorkflowInstanceImpl lockWorkflowInstance(WorkflowInstanceId workflowInstanceId, String owner) {
     WorkflowInstanceQuery query = new WorkflowInstanceQuery()
       .workflowInstanceId(workflowInstanceId);
     query.setLimit(1);

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/memory/MemoryWorkflowInstanceStore.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/memory/MemoryWorkflowInstanceStore.java
@@ -151,6 +151,11 @@ public class MemoryWorkflowInstanceStore implements WorkflowInstanceStore, Brewa
     return workflowInstance;
   }
 
+  @Override
+  public WorkflowInstanceImpl lockWorkflowInstance(WorkflowInstanceId workflowInstanceId) {
+    return lockWorkflowInstance(workflowInstanceId, workflowEngineId);
+  }
+
   public synchronized void lockWorkflowInstance(WorkflowInstanceImpl workflowInstance) {
     WorkflowInstanceId workflowInstanceId = workflowInstance.getId();
     if (lockedWorkflowInstanceIds.contains(workflowInstanceId)) {

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/workflowinstance/WorkflowInstanceImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/workflowinstance/WorkflowInstanceImpl.java
@@ -15,27 +15,12 @@
  */
 package com.effektif.workflow.impl.workflowinstance;
 
-import static com.effektif.workflow.impl.workflowinstance.ActivityInstanceImpl.*;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-
-import org.joda.time.LocalDateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.effektif.workflow.api.Configuration;
 import com.effektif.workflow.api.WorkflowEngine;
 import com.effektif.workflow.api.model.TriggerInstance;
 import com.effektif.workflow.api.model.WorkflowInstanceId;
 import com.effektif.workflow.api.query.WorkflowInstanceQuery;
 import com.effektif.workflow.api.workflowinstance.WorkflowInstance;
-import com.effektif.workflow.impl.ExecutorService;
 import com.effektif.workflow.impl.WorkflowEngineImpl;
 import com.effektif.workflow.impl.WorkflowInstanceStore;
 import com.effektif.workflow.impl.activity.ActivityType;
@@ -46,6 +31,13 @@ import com.effektif.workflow.impl.util.Time;
 import com.effektif.workflow.impl.workflow.ActivityImpl;
 import com.effektif.workflow.impl.workflow.MultiInstanceImpl;
 import com.effektif.workflow.impl.workflow.WorkflowImpl;
+import org.joda.time.LocalDateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+import static com.effektif.workflow.impl.workflowinstance.ActivityInstanceImpl.*;
 
 
 /**
@@ -376,18 +368,21 @@ public class WorkflowInstanceImpl extends ScopeInstanceImpl {
 
   /***
    * isIncluded
-   * @param query, with any combination of ActivityId and WorkflowInstanceId set or not set.
+   * @param query, with any combination of WorkflowId, ActivityId and WorkflowInstanceId set or not set.
    *               When set, the value is taken into account, otherwise it is ignored.
-   *               If both ActivityId and WorkflowInstanceId are null (empty query), true is returned
+   *               If WorkflowId, ActivityId and WorkflowInstanceId all are null (empty query), true is returned
+   *               Beware: if AT LEAST ONE of the conditions is met, true is returned!
    */
   public boolean isIncluded(WorkflowInstanceQuery query) {
 
-    if (query.getActivityId() == null && query.getWorkflowInstanceId() == null) return true;
+    if (query.getActivityId() == null && query.getWorkflowInstanceId() == null && query.getWorkflowId() == null) return true;
 
     if (query.getWorkflowInstanceId()!=null
             && query.getWorkflowInstanceId().equals(id)) {
       return true;
     }
+
+    if(query.getWorkflowId() != null && query.getWorkflowId().equals(workflow.getId().getInternal())) return true;
 
     if (query.getActivityId()!=null && hasActivityInstances()) {
       for (ActivityInstanceImpl activityInstance : activityInstances) {

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/workflowinstance/WorkflowInstanceImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/workflowinstance/WorkflowInstanceImpl.java
@@ -436,4 +436,11 @@ public class WorkflowInstanceImpl extends ScopeInstanceImpl {
   public WorkflowInstanceId getId() {
     return this.id;
   }
+
+  public void migrateToWorkflow(WorkflowImpl workflow) {
+    this.workflow = workflow;
+    if (updates != null) {
+      getUpdates().isWorkflowChanged = true;
+    }
+  }
 }

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/workflowinstance/WorkflowInstanceImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/workflowinstance/WorkflowInstanceImpl.java
@@ -436,11 +436,4 @@ public class WorkflowInstanceImpl extends ScopeInstanceImpl {
   public WorkflowInstanceId getId() {
     return this.id;
   }
-
-  public void migrateToWorkflow(WorkflowImpl workflow) {
-    this.workflow = workflow;
-    if (updates != null) {
-      getUpdates().isWorkflowChanged = true;
-    }
-  }
 }

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/workflowinstance/WorkflowInstanceUpdates.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/workflowinstance/WorkflowInstanceUpdates.java
@@ -27,6 +27,7 @@ public class WorkflowInstanceUpdates extends ScopeInstanceUpdates {
   public boolean isNextActivityInstanceIdChanged;
   public boolean isNextVariableInstanceIdChanged;
   public boolean isJobsChanged;
+  public boolean isWorkflowChanged;
 
   public WorkflowInstanceUpdates(boolean isNew) {
     this.isNew = isNew;
@@ -40,5 +41,6 @@ public class WorkflowInstanceUpdates extends ScopeInstanceUpdates {
     isNextActivityInstanceIdChanged = false;
     isNextVariableInstanceIdChanged = false;
     isJobsChanged = false;
+    isWorkflowChanged = false;
   }
 }

--- a/effektif-workflow-impl/src/test/java/com/effektif/workflow/test/serialization/SerializingWorkflowEngineImpl.java
+++ b/effektif-workflow-impl/src/test/java/com/effektif/workflow/test/serialization/SerializingWorkflowEngineImpl.java
@@ -18,6 +18,7 @@ package com.effektif.workflow.test.serialization;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.effektif.workflow.api.workflow.WorkflowInstanceMigrator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,6 +64,15 @@ public class SerializingWorkflowEngineImpl implements WorkflowEngine {
     log.debug("deployWorkflow");
     workflow = wireize(" >>workflow>> ", workflow);
     Deployment deployment = workflowEngine.deployWorkflow(workflow);
+    return wireize("  <<deployment<< ", deployment);
+  }
+
+  @Override
+  public Deployment deployWorkflow(ExecutableWorkflow workflow, WorkflowInstanceMigrator migrator) {
+    log.debug("deployWorkflow");
+    workflow = wireize(" >>workflow>> ", workflow);
+    migrator = wireize(" >>migrator>> ", migrator);
+    Deployment deployment = workflowEngine.deployWorkflow(workflow, migrator);
     return wireize("  <<deployment<< ", deployment);
   }
 


### PR DESCRIPTION
When deploying a new version of a workflow, existing workflowInstances can now be moved to this new workflow by specifying a new WorkflowMigrator object to the deploy() call of the WorkflowEngine.