### PR TITLE
Move to activity

### DIFF
--- a/effektif-adapter-activity/src/main/java/com/effektif/adapter/activity/AdapterActivityImpl.java
+++ b/effektif-adapter-activity/src/main/java/com/effektif/adapter/activity/AdapterActivityImpl.java
@@ -146,7 +146,9 @@ public class AdapterActivityImpl extends AbstractBindableActivityImpl<AdapterAct
         String variableId = outputBindings.get(outputParameterKey);
         TypedValue typedValue = outputParameterValues.get(outputParameterKey);
 //        DataTypeImpl dataType = outputParameterDataTypes.get(outputParameterKey);
-        activityInstance.setVariableValue(variableId, typedValue.getValue());
+        if(typedValue != null)
+          activityInstance.setVariableValue(variableId, typedValue.getValue());
+        else log.warn("Variable type not defined for variable " + variableId);
       }
     }
 

--- a/effektif-mongo/src/main/java/com/effektif/mongo/MongoWorkflowInstanceStore.java
+++ b/effektif-mongo/src/main/java/com/effektif/mongo/MongoWorkflowInstanceStore.java
@@ -15,20 +15,6 @@
  */
 package com.effektif.mongo;
 
-import static com.effektif.mongo.MongoHelper.*;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-
-import org.bson.types.ObjectId;
-import org.slf4j.Logger;
-
 import com.effektif.workflow.api.Configuration;
 import com.effektif.workflow.api.model.WorkflowId;
 import com.effektif.workflow.api.model.WorkflowInstanceId;
@@ -48,17 +34,14 @@ import com.effektif.workflow.impl.workflow.ActivityImpl;
 import com.effektif.workflow.impl.workflow.ScopeImpl;
 import com.effektif.workflow.impl.workflow.VariableImpl;
 import com.effektif.workflow.impl.workflow.WorkflowImpl;
-import com.effektif.workflow.impl.workflowinstance.ActivityInstanceImpl;
-import com.effektif.workflow.impl.workflowinstance.LockImpl;
-import com.effektif.workflow.impl.workflowinstance.ScopeInstanceImpl;
-import com.effektif.workflow.impl.workflowinstance.VariableInstanceImpl;
-import com.effektif.workflow.impl.workflowinstance.WorkflowInstanceImpl;
-import com.effektif.workflow.impl.workflowinstance.WorkflowInstanceUpdates;
-import com.mongodb.BasicDBList;
-import com.mongodb.BasicDBObject;
-import com.mongodb.BasicDBObjectBuilder;
-import com.mongodb.DBCursor;
-import com.mongodb.DBObject;
+import com.effektif.workflow.impl.workflowinstance.*;
+import com.mongodb.*;
+import org.bson.types.ObjectId;
+import org.slf4j.Logger;
+
+import java.util.*;
+
+import static com.effektif.mongo.MongoHelper.*;
 
 
 public class MongoWorkflowInstanceStore implements WorkflowInstanceStore, Brewable {
@@ -166,8 +149,14 @@ public class MongoWorkflowInstanceStore implements WorkflowInstanceStore, Brewab
 
     if (updates.isEndChanged) {
       // if (log.isDebugEnabled()) log.debug("  Workflow instance ended");
-      sets.append(WorkflowInstanceFields.END, workflowInstance.end.toDate());
-      sets.append(WorkflowInstanceFields.DURATION, workflowInstance.duration);
+      if (workflowInstance.end != null) {
+        sets.append(WorkflowInstanceFields.END, workflowInstance.end.toDate());
+        sets.append(WorkflowInstanceFields.DURATION, workflowInstance.duration);
+      }
+      else {
+        unsets.append(WorkflowInstanceFields.END, 1);
+        unsets.append(WorkflowInstanceFields.DURATION, 1);
+      }
     }
     // MongoDB can't combine updates of array elements together with 
     // adding elements to that array.  That's why we overwrite the whole

--- a/effektif-mongo/src/test/java/com/effektif/mongo/test/FindByActivityIdTest.java
+++ b/effektif-mongo/src/test/java/com/effektif/mongo/test/FindByActivityIdTest.java
@@ -7,6 +7,7 @@ import com.effektif.workflow.api.activities.*;
 import com.effektif.workflow.api.model.Deployment;
 import com.effektif.workflow.api.model.TriggerInstance;
 import com.effektif.workflow.api.query.WorkflowInstanceQuery;
+import com.effektif.workflow.api.query.WorkflowQuery;
 import com.effektif.workflow.api.workflow.ExecutableWorkflow;
 import com.effektif.workflow.api.workflowinstance.WorkflowInstance;
 
@@ -52,23 +53,22 @@ public class FindByActivityIdTest {
 
         WorkflowInstance workflowInstance = workflowEngine.start(start);
 
-        // Now find all workflowInstances in a particular ActivityId, they should be in "Three"
+        // Now check that the workflowInstance is in ActivityId "Three".
         WorkflowInstanceQuery workflowInstanceQuery = new WorkflowInstanceQuery()
                 .activityId("Three");
-
-        WorkflowInstanceQuery workflowInstanceQuery2 = new WorkflowInstanceQuery();
-//                .workflowInstanceId(workflowInstance.getId());
-
         List<WorkflowInstance> workflowInstances = workflowEngine.findWorkflowInstances(workflowInstanceQuery);
-
-        List<WorkflowInstance> workflowInstances2 = workflowEngine.findWorkflowInstances(workflowInstanceQuery2);
-
         System.out.println("Nr of workflowInstances found: " + workflowInstances.size() + " (should be 1)");
+
+        // Find all workflowInstances in the workflow
+        WorkflowInstanceQuery workflowInstanceQuery2 = new WorkflowInstanceQuery();
+        List<WorkflowInstance> workflowInstances2 = workflowEngine.findWorkflowInstances(workflowInstanceQuery2);
         System.out.println("Nr of workflowInstances found: " + workflowInstances2.size() + " (should be 1)");
 
-        TriggerInstance start2 = new TriggerInstance()
-                .workflowId(deployment.getWorkflowId());
+        // Now move the workflowInstance back to activityId "Two", the workflow should automatically advance it to "Three" again
+        workflowEngine.move(workflowInstance.getId(), "Two");
+        List<WorkflowInstance> workflowInstances4 = workflowEngine.findWorkflowInstances(workflowInstanceQuery);
 
+        // Add another workflowInstance to the workflow
         workflowInstance = workflowEngine.start(start);
 
         List<WorkflowInstance> workflowInstances3 = workflowEngine.findWorkflowInstances(workflowInstanceQuery2);
@@ -76,7 +76,14 @@ public class FindByActivityIdTest {
         System.out.println("Nr of workflowInstances found: " + workflowInstances.size() + " (should be 1)");
         System.out.println("Nr of workflowInstances found: " + workflowInstances2.size() + " (should be 1)");
         System.out.println("Nr of workflowInstances found: " + workflowInstances3.size() + " (should be 2)");
+        if(workflowInstances4.size() == 1) {
+            System.out.println("Number of activityInstances should be 5 now, it is: " + workflowInstances4.get(0).getActivityInstances().size());
+        }
+        else System.out.println("Move went wrong....");
 
+        // Cleanup
+        workflowEngine.deleteWorkflowInstances(new WorkflowInstanceQuery().activityId("Three"));
+        workflowEngine.deleteWorkflows(new WorkflowQuery().workflowId(workflow1.getId()));
     }
 
 }

--- a/effektif-mongo/src/test/java/com/effektif/mongo/test/FindByActivityIdTest.java
+++ b/effektif-mongo/src/test/java/com/effektif/mongo/test/FindByActivityIdTest.java
@@ -14,7 +14,7 @@ import com.effektif.workflow.api.workflowinstance.WorkflowInstance;
 import java.util.List;
 
 /**
- * Created by Jeroen on 12/06/15.
+ * Template for unit test to be created...
  */
 public class FindByActivityIdTest {
 
@@ -22,18 +22,13 @@ public class FindByActivityIdTest {
 
     public static void main(String[] args) {
 
-        Configuration mongoConfiguration = new MongoConfiguration()
+        cachedConfiguration = new MongoConfiguration()
                 .server("localhost")
                 .databaseName("effektif");
-
-        cachedConfiguration = mongoConfiguration;
 
         WorkflowEngine workflowEngine = cachedConfiguration.getWorkflowEngine();
 
         // Create a workflow
-        ExecutableWorkflow f = new ExecutableWorkflow();
-
-
         ExecutableWorkflow workflow1 = new ExecutableWorkflow()
                 .sourceWorkflowId("Server test workflow")
                 .activity("One", new StartEvent()
@@ -69,7 +64,7 @@ public class FindByActivityIdTest {
         List<WorkflowInstance> workflowInstances4 = workflowEngine.findWorkflowInstances(workflowInstanceQuery);
 
         // Add another workflowInstance to the workflow
-        workflowInstance = workflowEngine.start(start);
+        workflowEngine.start(start);
 
         List<WorkflowInstance> workflowInstances3 = workflowEngine.findWorkflowInstances(workflowInstanceQuery2);
 

--- a/effektif-workflow-api/src/main/java/com/effektif/workflow/api/WorkflowEngine.java
+++ b/effektif-workflow-api/src/main/java/com/effektif/workflow/api/WorkflowEngine.java
@@ -17,11 +17,7 @@ package com.effektif.workflow.api;
 
 import java.util.List;
 
-import com.effektif.workflow.api.model.Deployment;
-import com.effektif.workflow.api.model.Message;
-import com.effektif.workflow.api.model.TriggerInstance;
-import com.effektif.workflow.api.model.VariableValues;
-import com.effektif.workflow.api.model.WorkflowInstanceId;
+import com.effektif.workflow.api.model.*;
 import com.effektif.workflow.api.query.WorkflowInstanceQuery;
 import com.effektif.workflow.api.query.WorkflowQuery;
 import com.effektif.workflow.api.workflow.ExecutableWorkflow;
@@ -51,7 +47,9 @@ public interface WorkflowEngine {
   /** Sends a {@link Message message} to an activity instance, most likely this is invoked 
    * to end the specified activity instance and move workflow execution forward from there. */
   WorkflowInstance send(Message message);
-  
+
+  boolean move(WorkflowInstanceId workflowInstanceId, String toActivityId);
+
   VariableValues getVariableValues(WorkflowInstanceId workflowInstanceId);
 
   VariableValues getVariableValues(WorkflowInstanceId workflowInstanceId, String activityInstanceId);

--- a/effektif-workflow-api/src/main/java/com/effektif/workflow/api/WorkflowEngine.java
+++ b/effektif-workflow-api/src/main/java/com/effektif/workflow/api/WorkflowEngine.java
@@ -15,13 +15,13 @@
  */
 package com.effektif.workflow.api;
 
-import java.util.List;
-
 import com.effektif.workflow.api.model.*;
 import com.effektif.workflow.api.query.WorkflowInstanceQuery;
 import com.effektif.workflow.api.query.WorkflowQuery;
 import com.effektif.workflow.api.workflow.ExecutableWorkflow;
 import com.effektif.workflow.api.workflowinstance.WorkflowInstance;
+
+import java.util.List;
 
 
 /**
@@ -48,7 +48,8 @@ public interface WorkflowEngine {
    * to end the specified activity instance and move workflow execution forward from there. */
   WorkflowInstance send(Message message);
 
-  boolean move(WorkflowInstanceId workflowInstanceId, String toActivityId);
+  WorkflowInstance move(WorkflowInstanceId workflowInstanceId, String activityInstanceId, String newActivityId);
+  WorkflowInstance move(WorkflowInstanceId workflowInstanceId, String newActivityId);
 
   VariableValues getVariableValues(WorkflowInstanceId workflowInstanceId);
 

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
@@ -207,8 +207,6 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
    * Note: If your process contains a parallel gateway, and you move one of the two "instances" to an activity after the
    * merge-parallel gateway, things get messy.... The move() method is not checking for this situation, maybe that is something
    * to implement in the future, or prevent in the user interface.
-   * @param workflowInstanceId
-   * @param toActivityId
    * @return true is the to-activity was found, false otherwise.
    */
 

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
@@ -206,6 +206,8 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
 
     WorkflowInstanceImpl workflowInstance = lockWorkflowInstanceWithRetry(workflowInstanceId);
 
+    if (log.isDebugEnabled()) log.debug("Moving workflowInstance to activityId: " + toActivityId);
+
     if (workflowInstance.hasOpenActivityInstances()) {
       ActivityImpl activityImpl = workflowInstance.workflow.findActivityByIdLocal(toActivityId);
 

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
@@ -195,13 +195,12 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
   }
 
   /***
-   * To manually move a workflowInstance from the current (open) activityInstance to the specified activityInstance.
+   * To manually move a workflowInstance from the current activityInstance to the specified activityInstance.
    * Any "work" in between will not be executed! Will probably be used during testing of your workflows...
    * Note: If your process contains a parallel gateway, and you move one of the two "instances" to an activity after the
-   * merge-parallel gateway, things get messy.... The move() method is not checking for this situation, maybe that is something
-   * to implement in the future, or prevent in the user interface.
-   * Also, sub-processes are not taken into account ie, propagateToParent is not called.
-   * @return true is the to-activity was found, false otherwise.
+   * merge-parallel gateway, things would get messy.... Because of that, the move does not allow this, it checks for #open activityInstances <= 1
+   * Sub-processes are not taken into account ie, propagateToParent is not called.
+   * @return WorkflowInstance is the to-activity was found and the move was executed, null otherwise.
    */
   @Override
   public WorkflowInstance move(WorkflowInstanceId workflowInstanceId, String activityInstanceId, String newActivityId) {
@@ -241,6 +240,7 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
       return workflowInstance.toWorkflowInstance();
   }
 
+  @Override
   public WorkflowInstance move(WorkflowInstanceId workflowInstanceId, String newActivityId) {
     return move(workflowInstanceId, null, newActivityId);
   }

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
@@ -201,6 +201,17 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
     return send(message, workflowInstance);
   }
 
+  /***
+   * To manually move a workflowInstance from the current (open) activityInstance to the specified activityInstance.
+   * Any "work" in between will not be executed! Will probably be used during testing of your workflows...
+   * Note: If your process contains a parallel gateway, and you move one of the two "instances" to an activity after the
+   * merge-parallel gateway, things get messy.... The move() method is not checking for this situation, maybe that is something
+   * to implement in the future, or prevent in the user interface.
+   * @param workflowInstanceId
+   * @param toActivityId
+   * @return true is the to-activity was found, false otherwise.
+   */
+
   @Override
   public boolean move(WorkflowInstanceId workflowInstanceId, String toActivityId) {
 

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
@@ -207,6 +207,7 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
    * Note: If your process contains a parallel gateway, and you move one of the two "instances" to an activity after the
    * merge-parallel gateway, things get messy.... The move() method is not checking for this situation, maybe that is something
    * to implement in the future, or prevent in the user interface.
+   * Also, sub-processes are not taken into account ie, propagateToParent is not called.
    * @return true is the to-activity was found, false otherwise.
    */
 
@@ -217,7 +218,21 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
 
     if (log.isDebugEnabled()) log.debug("Moving workflowInstance to activityId: " + toActivityId);
 
-    if (workflowInstance.hasOpenActivityInstances()) {
+    if (workflowInstance.activityInstances==null) {
+      return false;
+    }
+
+    ActivityInstanceImpl activityInstanceImpl = null;
+    for (ActivityInstanceImpl activityInstance: workflowInstance.activityInstances) {
+      if (!activityInstance.isEnded()) {
+        activityInstanceImpl = activityInstance;
+        break;
+      }
+    }
+
+    if (activityInstanceImpl != null) {
+      activityInstanceImpl.end();
+
       ActivityImpl activityImpl = workflowInstance.workflow.findActivityByIdLocal(toActivityId);
 
       workflowInstance.execute(activityImpl);

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
@@ -201,6 +201,24 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
     return send(message, workflowInstance);
   }
 
+  @Override
+  public boolean move(WorkflowInstanceId workflowInstanceId, String toActivityId) {
+
+    WorkflowInstanceImpl workflowInstance = lockWorkflowInstanceWithRetry(workflowInstanceId);
+
+    if (workflowInstance.hasOpenActivityInstances()) {
+      ActivityImpl activityImpl = workflowInstance.workflow.findActivityByIdLocal(toActivityId);
+
+      workflowInstance.execute(activityImpl);
+
+      workflowInstance.executeWork();
+
+      return true;
+    }
+
+    return false;
+  }
+
   public WorkflowInstance send(Message message, WorkflowInstanceImpl workflowInstance) {
     workflowInstance.setVariableValues(message);
     String activityInstanceId = message.getActivityInstanceId();

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
@@ -227,17 +227,22 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
       activityInstanceImpl = workflowInstance.findActivityInstanceByActivityId(activityInstanceId);
     }
 
-    if (openActCount > 1) throw new RuntimeException("Move cannot be called on a workflowInstance with more than 1 open activityInstance. " +
+    if (openActCount > 1) throw new RuntimeException("Move cannot be called on a workflowInstance with more than one open activityInstance. " +
             "Propably this workflowInstance is part of a paralell process...");
 
+    ActivityImpl activityImpl = workflowInstance.workflow.findActivityByIdLocal(newActivityId);
+    if (activityImpl == null) throw new RuntimeException("To-activityId not found!");
+
     if (activityInstanceImpl != null && !activityInstanceImpl.isEnded()) activityInstanceImpl.end();
+    if (workflowInstance.isEnded()) {
+      workflowInstance.setEnd(null);
+      workflowInstance.duration = 0L;
+    }
 
-      ActivityImpl activityImpl = workflowInstance.workflow.findActivityByIdLocal(newActivityId);
-      if (activityImpl == null) throw new RuntimeException("To-activityId not found!");
+    workflowInstance.execute(activityImpl);
+    workflowInstance.executeWork();
 
-      workflowInstance.execute(activityImpl);
-      workflowInstance.executeWork();
-      return workflowInstance.toWorkflowInstance();
+    return workflowInstance.toWorkflowInstance();
   }
 
   @Override

--- a/effektif-workflow-impl/src/test/java/com/effektif/workflow/test/serialization/SerializingWorkflowEngineImpl.java
+++ b/effektif-workflow-impl/src/test/java/com/effektif/workflow/test/serialization/SerializingWorkflowEngineImpl.java
@@ -15,20 +15,19 @@
  */
 package com.effektif.workflow.test.serialization;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import com.effektif.workflow.api.model.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.effektif.workflow.api.WorkflowEngine;
+import com.effektif.workflow.api.model.*;
 import com.effektif.workflow.api.query.WorkflowInstanceQuery;
 import com.effektif.workflow.api.query.WorkflowQuery;
 import com.effektif.workflow.api.workflow.ExecutableWorkflow;
 import com.effektif.workflow.api.workflowinstance.WorkflowInstance;
 import com.effektif.workflow.impl.WorkflowEngineImpl;
 import com.effektif.workflow.impl.json.JsonStreamMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
@@ -103,9 +102,14 @@ public class SerializingWorkflowEngineImpl implements WorkflowEngine {
   }
 
   @Override
-  public boolean move(WorkflowInstanceId workflowInstanceId, String toActivityId) {
+  public WorkflowInstance move(WorkflowInstanceId workflowInstanceId, String activityInstanceId, String newActivityId) {
     log.debug("moveWorkflowInstance");
-    return workflowEngine.move(workflowInstanceId, toActivityId);
+    return workflowEngine.move(workflowInstanceId, newActivityId);
+  }
+
+  @Override
+  public WorkflowInstance move(WorkflowInstanceId workflowInstanceId, String newActivityId) {
+    return move(workflowInstanceId, null, newActivityId);
   }
 
   @Override

--- a/effektif-workflow-impl/src/test/java/com/effektif/workflow/test/serialization/SerializingWorkflowEngineImpl.java
+++ b/effektif-workflow-impl/src/test/java/com/effektif/workflow/test/serialization/SerializingWorkflowEngineImpl.java
@@ -18,15 +18,11 @@ package com.effektif.workflow.test.serialization;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.effektif.workflow.api.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.effektif.workflow.api.WorkflowEngine;
-import com.effektif.workflow.api.model.Deployment;
-import com.effektif.workflow.api.model.Message;
-import com.effektif.workflow.api.model.TriggerInstance;
-import com.effektif.workflow.api.model.VariableValues;
-import com.effektif.workflow.api.model.WorkflowInstanceId;
 import com.effektif.workflow.api.query.WorkflowInstanceQuery;
 import com.effektif.workflow.api.query.WorkflowQuery;
 import com.effektif.workflow.api.workflow.ExecutableWorkflow;
@@ -105,7 +101,13 @@ public class SerializingWorkflowEngineImpl implements WorkflowEngine {
     workflowInstance = wireize("  <<workflowInstance<< ", workflowInstance);
     return workflowInstance;
   }
-  
+
+  @Override
+  public boolean move(WorkflowInstanceId workflowInstanceId, String toActivityId) {
+    log.debug("moveWorkflowInstance");
+    return workflowEngine.move(workflowInstanceId, toActivityId);
+  }
+
   @Override
   public VariableValues getVariableValues(WorkflowInstanceId workflowInstanceId) {
     log.debug("getVariableValues");


### PR DESCRIPTION
To manually move a workflowInstance from the current (open) activityInstance to the specified activityInstance. Any "work" in between will not be executed! Will probably be used during testing of your workflows...

Note: If your process contains a parallel gateway, and you move one of the two "instances" to an activity after the merging parallel gateway, things get messy.... The move() method is not checking for this situation, maybe that is something to implement in the future, or prevent in the user interface.