### PR TITLE
Set/unset and store properties on workflowInstance level

### DIFF
--- a/effektif-mongo/src/main/java/com/effektif/mongo/MongoWorkflowInstanceStore.java
+++ b/effektif-mongo/src/main/java/com/effektif/mongo/MongoWorkflowInstanceStore.java
@@ -182,14 +182,14 @@ public class MongoWorkflowInstanceStore implements WorkflowInstanceStore, Brewab
 //      if (!dbArchivedActivityInstances.isEmpty()) {
 //        update.append("$push", new BasicDBObject(WorkflowInstanceFields.ARCHIVED_ACTIVITY_INSTANCES, dbArchivedActivityInstances));
 //      }
-    } else {
+//    } else {
       // if (log.isDebugEnabled()) log.debug("  No activity instances changed");
     }
     
     if (updates.isVariableInstancesChanged) {
       // if (log.isDebugEnabled()) log.debug("  Variable instances changed");
       writeVariableInstances(sets, workflowInstance);
-    } else {
+//    } else {
       // if (log.isDebugEnabled()) log.debug("  No variable instances changed");
     }
 
@@ -201,7 +201,7 @@ public class MongoWorkflowInstanceStore implements WorkflowInstanceStore, Brewab
       } else {
         unsets.put(WorkflowInstanceFields.WORK, 1);
       }
-    } else {
+//    } else {
       // if (log.isDebugEnabled()) log.debug("  No work changed");
     }
 
@@ -213,7 +213,7 @@ public class MongoWorkflowInstanceStore implements WorkflowInstanceStore, Brewab
       } else {
         unsets.put(WorkflowInstanceFields.WORK_ASYNC, 1);
       }
-    } else {
+//    } else {
       // if (log.isDebugEnabled()) log.debug("  No async work changed");
     }
 
@@ -241,24 +241,31 @@ public class MongoWorkflowInstanceStore implements WorkflowInstanceStore, Brewab
       } else {
         unsets.put(WorkflowInstanceFields.JOBS, 1);
       }
-    } else {
+//    } else {
       // if (log.isDebugEnabled()) log.debug("  No jobs changed");
+    }
+
+    if (updates.isPropertiesChanged) {
+      if (workflowInstance.properties != null && workflowInstance.properties.size() > 0)
+        sets.append(WorkflowInstanceFields.PROPERTIES, new BasicDBObject(workflowInstance.getProperties()));
+      else
+        unsets.append(WorkflowInstanceFields.PROPERTIES, 1);
     }
 
     if (!sets.isEmpty()) {
       update.append("$set", sets);
-    } else {
+//    } else {
       // if (log.isDebugEnabled()) log.debug("  No sets");
     }
     if (!unsets.isEmpty()) {
       update.append("$unset", unsets);
-    } else {
+//    } else {
       // if (log.isDebugEnabled()) log.debug("  No unsets");
     }
     
     if (!update.isEmpty()) {
       workflowInstancesCollection.update("flush-workflow-instance", query, update, false, false);
-    } else {
+//    } else {
       // if (log.isDebugEnabled()) log.debug("  Nothing to flush");
     }
     

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/workflowinstance/WorkflowInstanceImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/workflowinstance/WorkflowInstanceImpl.java
@@ -353,7 +353,31 @@ public class WorkflowInstanceImpl extends ScopeInstanceImpl {
       getUpdates().isEndChanged = true;
     }
   }
-  
+
+  @Override
+  public void setProperty(String key, Object value) {
+    super.setProperty(key, value);
+    getUpdates().isPropertiesChanged = true;
+  }
+
+  @Override
+  public void setPropertyOpt(String key, Object value) {
+    getUpdates().isPropertiesChanged = true;
+    super.setPropertyOpt(key, value);
+  }
+
+  @Override
+  public void setProperties(Map<String, Object> properties) {
+    getUpdates().isPropertiesChanged = true;
+    super.setProperties(properties);
+  }
+
+  @Override
+  public Object removeProperty(String key) {
+    getUpdates().isPropertiesChanged = true;
+    return super.removeProperty(key);
+  }
+
   /** getter for casting convenience */ 
   @Override
   public WorkflowInstanceUpdates getUpdates() {

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/workflowinstance/WorkflowInstanceUpdates.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/workflowinstance/WorkflowInstanceUpdates.java
@@ -27,6 +27,7 @@ public class WorkflowInstanceUpdates extends ScopeInstanceUpdates {
   public boolean isNextActivityInstanceIdChanged;
   public boolean isNextVariableInstanceIdChanged;
   public boolean isJobsChanged;
+  public boolean isPropertiesChanged;
 
   public WorkflowInstanceUpdates(boolean isNew) {
     this.isNew = isNew;
@@ -40,5 +41,6 @@ public class WorkflowInstanceUpdates extends ScopeInstanceUpdates {
     isNextActivityInstanceIdChanged = false;
     isNextVariableInstanceIdChanged = false;
     isJobsChanged = false;
+    isPropertiesChanged = false;
   }
 }


### PR DESCRIPTION
Useful when you want custom properties in a workflowInstance.

The properties are stored under the "properties" section in the workflowInstance. Only basic json types can be used (String, Boolean, Number, Array or Map)

The api was already in place, the only thing that was missing was that the properties were not stored in Mongo after they were set (using setProperty() on a workflowInstanceImpl object).
This code implements storing the changes.
