### PR TITLE
#51 fixed concurrent modification exception

### DIFF
--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/WorkflowEngineImpl.java
@@ -176,9 +176,7 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
 
     notifyInsert(workflowInstance);
     workflowInstanceStore.insertWorkflowInstance(workflowInstance);
-    workflowInstance.executeWork();
-
-    return workflowInstance.toWorkflowInstance();
+    return workflowInstance.executeWork();
   }
 
   public WorkflowId getLatestWorkflowId(TriggerInstance triggerInstance) {
@@ -259,9 +257,7 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
       }
 
       workflowInstanceImpl.execute(activityImpl);
-      workflowInstanceImpl.executeWork();
-
-      return workflowInstanceImpl.toWorkflowInstance();
+      return workflowInstanceImpl.executeWork();
     } finally {
       workflowInstanceStore.unlockWorkflowInstance(workflowInstanceImpl);
     }
@@ -296,8 +292,7 @@ public class WorkflowEngineImpl implements WorkflowEngine, Brewable {
       log.debug("Signalling "+activityInstance);
     ActivityImpl activity = activityInstance.getActivity();
     activity.activityType.message(activityInstance, message);
-    workflowInstance.executeWork();
-    return workflowInstance.toWorkflowInstance();
+    return workflowInstance.executeWork();
   }
 
   @Override

--- a/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/workflowinstance/WorkflowInstanceImpl.java
+++ b/effektif-workflow-impl/src/main/java/com/effektif/workflow/impl/workflowinstance/WorkflowInstanceImpl.java
@@ -131,7 +131,7 @@ public class WorkflowInstanceImpl extends ScopeInstanceImpl {
     return workflowInstances;
   }
 
-  public void executeWork() {
+  public WorkflowInstance executeWork() {
     boolean isFirst = true;
     while (hasWork()) {
       ActivityInstanceImpl activityInstance = getNextWork();
@@ -199,6 +199,7 @@ public class WorkflowInstanceImpl extends ScopeInstanceImpl {
         }
       }
     }
+    WorkflowInstance workflowInstanceSnapshot = workflowInstance.toWorkflowInstance();
     if (hasAsyncWork()) {
       if (log.isDebugEnabled())
         log.debug("Going asynchronous " + this);
@@ -226,6 +227,7 @@ public class WorkflowInstanceImpl extends ScopeInstanceImpl {
       workflowInstanceStore.flushAndUnlock(this);
       workflow.workflowEngine.notifyUnlocked(this);
     }
+    return workflowInstanceSnapshot;
   }
 
   public void cancel() {


### PR DESCRIPTION
Solution was to make a serializable snapshot copy inside the `executeWork` method, before the asynchronous work is being started.